### PR TITLE
Fix issue #107

### DIFF
--- a/project/main/business/get_business_helper.py
+++ b/project/main/business/get_business_helper.py
@@ -134,14 +134,6 @@ def isAerealQhawax(qhawax_name):
         return True
     return None
 
-def getAllStaticQhawaxID():
-    """ Get all qHAWAXs STATIC (int or ext) ID - No parameters required """
-    base_string = "STATIC"
-    search = "%{}%".format(base_string)
-    qhawax_list =  session.query(Qhawax.id).filter(Qhawax.qhawax_type.like(search)). \
-                        order_by(Qhawax.id).all()
-    return [qhawax._asdict() for qhawax in qhawax_list]
-
 def getAllStaticQhawaxInstallationID():
     """ Get all qHAWAXs STATIC (int or ext) Installation ID - No parameters required """
     base_string = "STATIC"
@@ -152,13 +144,36 @@ def getAllStaticQhawaxInstallationID():
                         order_by(QhawaxInstallationHistory.id.desc()).all()
     return [qhawax._asdict() for qhawax in qhawax_list]
 
-def getAllMobileQhawaxID():
-    """ Gets all mobile qHAWAXs - No parameters required """
-    base_string = "MOBILE_EXT"
+
+def getAllQhawaxID_helper(base_string):
+    """
+    Helper for getting all qHAWAXs ID by the specified base_string.
+
+    Parameters required:
+    STATIC - Get all qHAWAXs STATIC (int or ext) ID
+    MOBILE_EXT - Gets all mobile qHAWAXs ID
+    """
     search = "%{}%".format(base_string)
-    qhawax_list =  session.query(Qhawax.id).filter(Qhawax.qhawax_type.like(search)). \
-                        order_by(Qhawax.id).all()
+    qhawax_list = (
+        session.query(Qhawax.id)
+        .filter(Qhawax.qhawax_type.like(search))
+        .order_by(Qhawax.id)
+        .all()
+    )
     return [qhawax._asdict() for qhawax in qhawax_list]
+
+
+def getAllStaticQhawaxID():
+    """Get all qHAWAXs STATIC (int or ext) ID - No parameters required"""
+    base_string = "STATIC"
+    return getAllQhawaxID_helper(base_string)
+
+
+def getAllMobileQhawaxID():
+    """Gets all mobile qHAWAXs - No parameters required"""
+    base_string = "MOBILE_EXT"
+    return getAllQhawaxID_helper(base_string)
+
 
 def queryLastTimePhysicallyTurnOnZone(qhawax_name):
     qhawax_id = same_helper.getQhawaxID(qhawax_name)


### PR DESCRIPTION
1. Write a helper function _getAllQhawaxID_helper_ as a helper for getting all qHAWAXs ID by the specified base_string. 

    The base_string could be:
    
    - STATIC: to get all qHAWAXs STATIC (int or ext) ID
    - MOBILE_EXT: to get all mobile qHAWAXs ID

2. Modify the two functions, _getAllStaticQhawaxID_ and _getAllMobileQhawaxID_ to avoid reused code blocks by using the helper above.